### PR TITLE
Fix/minors

### DIFF
--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -72,11 +72,7 @@ func domain_to_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
     if (resolver == 0) {
         let (hashed_domain) = hash_domain(domain_len, domain);
         let (domain_data) = _domain_data.read(hashed_domain);
-        if (domain_data.address == FALSE) {
-            return (address=0);
-        } else {
-            return (domain_data.address,);
-        }
+        return (domain_data.address,);
     } else {
         let (address) = Resolver.domain_to_address(resolver, rest_len, rest);
         return (address=address);

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -337,13 +337,10 @@ func transfer_domain{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
     let (current_domain_data) = _domain_data.read(hashed_domain);
     let (contract) = starknetid_contract.read();
     let (naming_contract) = get_contract_address();
-    let (data: felt) = StarknetId.get_verifier_data(
-        contract, target_token_id, 'name', naming_contract
-    );
     // ensure target doesn't already have a domain
-    with_attr error_message("Target token_id already has a domain") {
-        assert data = 0;
-    }
+    let (current_timestamp) = get_block_timestamp();
+    assert_empty_starknet_id(target_token_id, current_timestamp, naming_contract);
+
     if (current_domain_data.parent_key == 0) {
         let (hashed_parent_domain) = hash_domain(domain_len - 1, domain + 1);
         let (next_domain_data) = _domain_data.read(hashed_parent_domain);

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -89,11 +89,7 @@ func domain_to_expiry{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
 ) -> (expiry: felt) {
     let (hashed_domain) = hash_domain(domain_len, domain);
     let (domain_data) = _domain_data.read(hashed_domain);
-    if (domain_data.expiry == FALSE) {
-        return (0,);
-    } else {
-        return (domain_data.expiry,);
-    }
+    return (domain_data.expiry,);
 }
 
 @view

--- a/src/naming/registration.cairo
+++ b/src/naming/registration.cairo
@@ -113,7 +113,7 @@ func assert_empty_starknet_id{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ra
         contract_addr, starknet_id, 'name', naming_contract
     );
 
-    with_attr error_message("This StarknetId already has a domain") {
+    with_attr error_message("This starknet_id already has a domain") {
         // if a domain was written, check if it expired
         if (sid_hashed_domain != 0) {
             let (data) = _domain_data.read(sid_hashed_domain);

--- a/src/naming/registration.cairo
+++ b/src/naming/registration.cairo
@@ -117,11 +117,18 @@ func assert_empty_starknet_id{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ra
         // if a domain was written, check if it expired
         if (sid_hashed_domain != 0) {
             let (data) = _domain_data.read(sid_hashed_domain);
-            assert_le_felt(data.expiry, current_timestamp);
-            // because cairo is hell
-            tempvar syscall_ptr = syscall_ptr;
-            tempvar pedersen_ptr = pedersen_ptr;
-            tempvar range_check_ptr = range_check_ptr;
+            if (data.expiry != 0) {
+                assert_le_felt(data.expiry, current_timestamp);
+                // because cairo is hell
+                tempvar syscall_ptr = syscall_ptr;
+                tempvar pedersen_ptr = pedersen_ptr;
+                tempvar range_check_ptr = range_check_ptr;
+            } else {
+                assert 1 = 0;
+                tempvar syscall_ptr = syscall_ptr;
+                tempvar pedersen_ptr = pedersen_ptr;
+                tempvar range_check_ptr = range_check_ptr;
+            }
         } else {
             tempvar syscall_ptr = syscall_ptr;
             tempvar pedersen_ptr = pedersen_ptr;

--- a/tests/test_situations.cairo
+++ b/tests/test_situations.cairo
@@ -116,7 +116,7 @@ func test_simple_buy_fails_non_empty_starknet_id{
         stop_prank_callable = start_prank(456)
         stop_mock = mock_call(123, "transferFrom", [1])
         warp(1, context.naming_contract)
-        expect_revert(error_message="This StarknetId already has a domain")
+        expect_revert(error_message="This starknet_id already has a domain")
     %}
 
     let token_id = 1;
@@ -518,14 +518,18 @@ func test_transfer_subdomain{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: 
     let token_id2 = 2;
     StarknetId.mint(starknet_id_contract, token_id2);
 
+    let token_id3 = 3;
+    StarknetId.mint(starknet_id_contract, token_id3);
+
     // th0rgal encoded
     let th0rgal_string = 28235132438;
 
     Naming.buy(naming_contract, token_id, th0rgal_string, 365, 0, 456);
     Naming.transfer_domain(naming_contract, 2, new (th0rgal_string, th0rgal_string), token_id2);
+    Naming.buy(naming_contract, token_id3, 987654321, 365, 0, 456);
 
-    %{ expect_revert(error_message="Target token_id already has a domain") %}
-    Naming.transfer_domain(naming_contract, 1, new (th0rgal_string), token_id2);
+    %{ expect_revert(error_message="This starknet_id already has a domain") %}
+    Naming.transfer_domain(naming_contract, 1, new (th0rgal_string), token_id3);
 
     %{
         stop_prank_callable()

--- a/tests/test_situations.cairo
+++ b/tests/test_situations.cairo
@@ -511,31 +511,23 @@ func test_transfer_subdomain{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: 
         stop_mock = mock_call(123, "transferFrom", [1])
         warp(1, context.naming_contract)
     %}
-
     let token_id = 1;
     StarknetId.mint(starknet_id_contract, token_id);
-
     let token_id2 = 2;
     StarknetId.mint(starknet_id_contract, token_id2);
-
-    let token_id3 = 3;
-    StarknetId.mint(starknet_id_contract, token_id3);
-
     // th0rgal encoded
     let th0rgal_string = 28235132438;
-
+    // buying th0rgal.stark and creating th0rgal.th0rgal.stark
     Naming.buy(naming_contract, token_id, th0rgal_string, 365, 0, 456);
     Naming.transfer_domain(naming_contract, 2, new (th0rgal_string, th0rgal_string), token_id2);
-    Naming.buy(naming_contract, token_id3, 987654321, 365, 0, 456);
-
+    // trying to transfer th0rgal.stark to starknet_id containg th0rgal.th0rgal.stark
     %{ expect_revert(error_message="This starknet_id already has a domain") %}
-    Naming.transfer_domain(naming_contract, 1, new (th0rgal_string), token_id3);
+    Naming.transfer_domain(naming_contract, 1, new (th0rgal_string), token_id2);
 
     %{
         stop_prank_callable()
         stop_mock()
     %}
-
     return ();
 }
 


### PR DESCRIPTION
This fixes:
- starknet_id already has a domain error when it doesn't
- reset_subdomains didn't update domain resolving

Question:
Instead of returning 0 when resolving fails, should we make the tx fail? If we do it would avoid an invalid tx to pass in a multicall, but it would not support all cases (by default a domain that doesn't resolve would return 0) and would need make integration a lil bit harder. 