### PR TITLE
fix: undetected custom resolver

### DIFF
--- a/src/naming/registration.cairo
+++ b/src/naming/registration.cairo
@@ -113,7 +113,9 @@ func mint_domain{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     domain_to_addr_update.emit(1, new (domain), target_address);
     let (contract) = starknetid_contract.read();
     StarknetId.set_verifier_data(contract, token_id, 'name', hashed_domain);
-
+    if (resolver != 0) {
+        domain_to_resolver_update.emit(1, new(domain), resolver);
+    }
     return ();
 }
 


### PR DESCRIPTION
This pull request fixes the fact a domain name minted with custom resolver would not get caught by the indexer.