### PR TITLE
Feat/new renewal interface

### DIFF
--- a/src/interface/naming.cairo
+++ b/src/interface/naming.cairo
@@ -44,7 +44,7 @@ namespace Naming {
     ) {
     }
 
-    func renew(domain: felt, days: felt, sponsor: felt) {
+    func renew(domain: felt, days: felt, sponsor: felt, discount_id : felt, metadata : felt) {
     }
 
     func transfer_domain(domain_len: felt, domain: felt*, target_token_id: felt) {

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -310,7 +310,7 @@ func buy_discounted{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_
 
 @external
 func renew{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    domain: felt, days: felt, sponsor: felt
+    domain: felt, days: felt, sponsor: felt, discount_id : felt, metadata : felt
 ) {
     alloc_locals;
 

--- a/tests/integration/test_buying.cairo
+++ b/tests/integration/test_buying.cairo
@@ -202,7 +202,7 @@ func test_expired_renew{syscall_ptr: felt*, range_check_ptr, pedersen_ptr: HashB
     Naming.buy(naming_contract, token_id, th0rgal_string, 365, 0, 456, 0);
     let (addr) = Naming.domain_to_address(naming_contract, 1, new (th0rgal_string));
     assert addr = 456;
-    Naming.renew(naming_contract, th0rgal_string, 365, 0);
+    Naming.renew(naming_contract, th0rgal_string, 365, 0, 0, 0);
     %{
         stop_prank_callable_1()
         stop_prank_callable_2()


### PR DESCRIPTION
This pull request adds two (unused) params to the renew function to allow for a simple transition from cairo 0 to cairo 2 on the autorenewal side. This will require change on both the autorenewal bot and the app frontend